### PR TITLE
refactor: cleanup `TextState` interface

### DIFF
--- a/examples/text.rs
+++ b/examples/text.rs
@@ -146,11 +146,14 @@ impl<'a> App<'a> {
 
             // Get the text state and reshape if needed
             if let Some(text_state) = self.text_manager.text_states.get_mut(&text_id) {
-                text_state.params = params.clone();
-                text_state.reshape_if_params_changed(&mut self.text_manager.text_context, None);
+                text_state.set_text(params.original_text());
+                text_state.set_outer_size(&params.size());
+                text_state.set_style(params.style());
+                text_state.set_buffer_id(&params.buffer_id());
+                text_state.recalculate(&mut self.text_manager.text_context);
 
                 // Now here's the key part: use protextinator's buffer with grafo's add_text_buffer!
-                let buffer = &text_state.buffer;
+                let buffer = &text_state.buffer();
                 // Define the area where the text should be rendered
                 let text_area = MathRect {
                     min: (text_rect.min.x, text_rect.min.y).into(),
@@ -190,7 +193,7 @@ impl<'a> App<'a> {
                 let stats_id = Id::new("stats_text");
                 let stats_text = format!(
                     "Protextinator Stats:\n• Text lines in buffer: {}\n• Total characters: {}\n• Cached buffers: {}\n• Buffer metadata ID: {}", 
-                    text_state.buffer.lines.len(),
+                    text_state.buffer().lines.len(),
                     self.text_content.len(),
                     self.text_manager.text_states.len(),
                     text_id.0
@@ -227,12 +230,14 @@ impl<'a> App<'a> {
 
                 // Get the stats text state and reshape if needed
                 if let Some(stats_text_state) = self.text_manager.text_states.get_mut(&stats_id) {
-                    stats_text_state.params = stats_params.clone();
-                    stats_text_state
-                        .reshape_if_params_changed(&mut self.text_manager.text_context, None);
+                    stats_text_state.set_text(stats_params.original_text());
+                    stats_text_state.set_outer_size(&stats_params.size());
+                    stats_text_state.set_style(stats_params.style());
+                    stats_text_state.set_buffer_id(&stats_params.buffer_id());
+                    stats_text_state.recalculate(&mut self.text_manager.text_context);
 
                     // Render stats using add_text_buffer as well
-                    let stats_buffer = &stats_text_state.buffer;
+                    let stats_buffer = &stats_text_state.buffer();
                     let stats_area = MathRect {
                         min: (stats_rect.min.x, stats_rect.min.y).into(),
                         max: (stats_rect.max.x, stats_rect.max.y).into(),

--- a/src/style.rs
+++ b/src/style.rs
@@ -1,9 +1,8 @@
-use std::borrow::Cow;
+use crate::utils::ArcCowStr;
 use cosmic_text::{Align, Color, Family};
 #[cfg(feature = "serialization")]
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::hash::Hash;
-use crate::utils::ArcCowStr;
 
 #[cfg_attr(feature = "serialization", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]

--- a/src/tests/caret_positioning.rs
+++ b/src/tests/caret_positioning.rs
@@ -1,4 +1,3 @@
-use crate::state::UpdateReason;
 use crate::tests::mono_style_test;
 use crate::{Action, ActionResult, Id, Point, TextContext, TextState};
 
@@ -9,43 +8,43 @@ pub fn test() {
     let initial_text = "Hello World".to_string();
 
     let mut text_state = TextState::new_with_text(initial_text, text_id, &mut ctx.font_system);
-    text_state.params.set_style(&mono_style_test());
-    text_state.params.set_size(&Point::from((200.0, 25.0)));
+    text_state.set_style(&mono_style_test());
+    text_state.set_outer_size(&Point::from((200.0, 25.0)));
     text_state.is_editable = true;
     text_state.is_editing = true;
     text_state.is_selectable = true;
     text_state.are_actions_enabled = true;
-    text_state.recalculate(&mut ctx, UpdateReason::Unknown);
+    text_state.recalculate(&mut ctx);
     let mono_width = text_state.first_glyph().unwrap().w;
 
     assert!(mono_width > 0.0);
 
-    assert_eq!(text_state.cursor.char_index(text_state.text()), Some(0));
-    assert_eq!(text_state.relative_caret_offset_horizontal, 0.0);
+    assert_eq!(text_state.cursor_char_index(), Some(0));
+    assert_eq!(text_state.caret_position_relative().x, 0.0);
 
     text_state.handle_press(&mut ctx, Point { x: 25.0, y: 10.0 });
-    assert_eq!(text_state.cursor.char_index(text_state.text()), Some(3));
+    assert_eq!(text_state.cursor_char_index(), Some(3));
     assert_eq!(
-        text_state.relative_caret_offset_horizontal,
+        text_state.caret_position_relative().x,
         (mono_width * 3.0).floor()
     );
 
     let result = text_state.apply_action(&mut ctx, &Action::InsertChar("a".into()));
     assert!(matches!(result, ActionResult::TextChanged));
-    assert_eq!(text_state.text_size(), 12);
-    assert_eq!(text_state.cursor.char_index(text_state.text()), Some(4));
+    assert_eq!(text_state.text_char_len(), 12);
+    assert_eq!(text_state.cursor_char_index(), Some(4));
     assert_eq!(
-        text_state.relative_caret_offset_horizontal,
+        text_state.caret_position_relative().x,
         (mono_width * 4.0).floor()
     );
     assert_eq!(text_state.text(), "Helalo World");
 
     let result = text_state.apply_action(&mut ctx, &Action::MoveCursorRight);
     assert!(matches!(result, ActionResult::CursorUpdated));
-    assert_eq!(text_state.text_size(), 12);
-    assert_eq!(text_state.cursor.char_index(text_state.text()), Some(5));
+    assert_eq!(text_state.text_char_len(), 12);
+    assert_eq!(text_state.cursor_char_index(), Some(5));
     assert_eq!(
-        text_state.relative_caret_offset_horizontal,
+        text_state.caret_position_relative().x,
         (mono_width * 5.0).floor()
     );
 }
@@ -57,63 +56,63 @@ pub fn test_cyrillic() {
     let initial_text = "Привет Мир".to_string();
 
     let mut text_state = TextState::new_with_text(initial_text, text_id, &mut ctx.font_system);
-    text_state.params.set_style(&mono_style_test());
-    text_state.params.set_size(&Point::from((200.0, 25.0)));
+    text_state.set_style(&mono_style_test());
+    text_state.set_outer_size(&Point::from((200.0, 25.0)));
     text_state.is_editable = true;
     text_state.is_editing = true;
     text_state.is_selectable = true;
     text_state.are_actions_enabled = true;
 
-    text_state.recalculate(&mut ctx, UpdateReason::Unknown);
+    text_state.recalculate(&mut ctx);
     let mono_width = text_state.first_glyph().unwrap().w;
 
     assert!(mono_width > 0.0);
 
-    assert_eq!(text_state.text_size(), 10);
-    assert_eq!(text_state.cursor.char_index(text_state.text()), Some(0));
-    assert_eq!(text_state.relative_caret_offset_horizontal, 0.0);
+    assert_eq!(text_state.text_char_len(), 10);
+    assert_eq!(text_state.cursor_char_index(), Some(0));
+    assert_eq!(text_state.caret_position_relative().x, 0.0);
 
     let result = text_state.apply_action(&mut ctx, &Action::MoveCursorRight);
     assert!(matches!(result, ActionResult::CursorUpdated));
-    assert_eq!(text_state.text_size(), 10);
-    assert_eq!(text_state.cursor.char_index(text_state.text()), Some(1));
+    assert_eq!(text_state.text_char_len(), 10);
+    assert_eq!(text_state.cursor_char_index(), Some(1));
     assert_eq!(
-        text_state.relative_caret_offset_horizontal,
+        text_state.caret_position_relative().x,
         (mono_width * 1.0).floor()
     );
 
     let result = text_state.apply_action(&mut ctx, &Action::MoveCursorRight);
     assert!(matches!(result, ActionResult::CursorUpdated));
-    assert_eq!(text_state.text_size(), 10);
-    assert_eq!(text_state.cursor.char_index(text_state.text()), Some(2));
+    assert_eq!(text_state.text_char_len(), 10);
+    assert_eq!(text_state.cursor_char_index(), Some(2));
     assert_eq!(
-        text_state.relative_caret_offset_horizontal,
+        text_state.caret_position_relative().x,
         (mono_width * 2.0).floor()
     );
 
     text_state.handle_press(&mut ctx, Point { x: 25.0, y: 10.0 });
-    assert_eq!(text_state.cursor.char_index(text_state.text()), Some(3));
+    assert_eq!(text_state.cursor_char_index(), Some(3));
     assert_eq!(
-        text_state.relative_caret_offset_horizontal,
+        text_state.caret_position_relative().x,
         (mono_width * 3.0).floor()
     );
 
     let result = text_state.apply_action(&mut ctx, &Action::InsertChar("ш".into()));
     assert!(matches!(result, ActionResult::TextChanged));
-    assert_eq!(text_state.text_size(), 11);
-    assert_eq!(text_state.cursor.char_index(text_state.text()), Some(4));
+    assert_eq!(text_state.text_char_len(), 11);
+    assert_eq!(text_state.cursor_char_index(), Some(4));
     assert_eq!(
-        text_state.relative_caret_offset_horizontal,
+        text_state.caret_position_relative().x,
         (mono_width * 4.0).floor()
     );
     assert_eq!(text_state.text(), "Пришвет Мир");
 
     let result = text_state.apply_action(&mut ctx, &Action::MoveCursorRight);
     assert!(matches!(result, ActionResult::CursorUpdated));
-    assert_eq!(text_state.text_size(), 11);
-    assert_eq!(text_state.cursor.char_index(text_state.text()), Some(5));
+    assert_eq!(text_state.text_char_len(), 11);
+    assert_eq!(text_state.cursor_char_index(), Some(5));
     assert_eq!(
-        text_state.relative_caret_offset_horizontal,
+        text_state.caret_position_relative().x,
         (mono_width * 5.0).floor()
     );
 }
@@ -127,38 +126,38 @@ pub fn test_insert_into_empty_text() {
     let initial_text = "".to_string(); // Empty text
 
     let mut text_state = TextState::new_with_text(initial_text, text_id, &mut ctx.font_system);
-    text_state.params.set_style(&mono_style_test());
-    text_state.params.set_size(&Point::from((200.0, 25.0)));
+    text_state.set_style(&mono_style_test());
+    text_state.set_outer_size(&Point::from((200.0, 25.0)));
     text_state.is_editable = true;
     text_state.is_editing = true;
     text_state.is_selectable = true;
     text_state.are_actions_enabled = true;
 
-    text_state.recalculate(&mut ctx, UpdateReason::Unknown);
+    text_state.recalculate(&mut ctx);
 
     // Verify initial state
-    assert_eq!(text_state.text_size(), 0);
-    assert_eq!(text_state.cursor.char_index(text_state.text()), Some(0));
-    assert_eq!(text_state.relative_caret_offset_horizontal, 0.0);
+    assert_eq!(text_state.text_char_len(), 0);
+    assert_eq!(text_state.cursor_char_index(), Some(0));
+    assert_eq!(text_state.caret_position_relative().x, 0.0);
 
     // Insert the first character
     let result = text_state.apply_action(&mut ctx, &Action::InsertChar("a".into()));
     assert!(matches!(result, ActionResult::TextChanged));
 
     // Verify text was inserted
-    assert_eq!(text_state.text_size(), 1);
+    assert_eq!(text_state.text_char_len(), 1);
     assert_eq!(text_state.text(), "a");
 
     // Verify cursor position - this should fail due to the bug
     // The cursor should be at position 1 (after the inserted character)
-    assert_eq!(text_state.cursor.char_index(text_state.text()), Some(1));
+    assert_eq!(text_state.cursor_char_index(), Some(1));
 
     // Verify caret offset - this should fail due to the bug
     // The caret should have moved to the right
     let mono_width = text_state.first_glyph().unwrap().w;
 
     assert_eq!(
-        text_state.relative_caret_offset_horizontal,
+        text_state.caret_position_relative().x,
         (mono_width * 1.0).floor()
     );
 }
@@ -172,14 +171,14 @@ pub fn test_delete_at_end_of_text() {
     let initial_text = "Hello".to_string();
 
     let mut text_state = TextState::new_with_text(initial_text, text_id, &mut ctx.font_system);
-    text_state.params.set_style(&mono_style_test());
-    text_state.params.set_size(&Point::from((200.0, 25.0)));
+    text_state.set_style(&mono_style_test());
+    text_state.set_outer_size(&Point::from((200.0, 25.0)));
     text_state.is_editable = true;
     text_state.is_editing = true;
     text_state.is_selectable = true;
     text_state.are_actions_enabled = true;
 
-    text_state.recalculate(&mut ctx, UpdateReason::Unknown);
+    text_state.recalculate(&mut ctx);
 
     // Move cursor to the end of the text
     for _ in 0..5 {
@@ -187,8 +186,8 @@ pub fn test_delete_at_end_of_text() {
     }
 
     // Verify cursor is at the end of the text
-    assert_eq!(text_state.cursor.char_index(text_state.text()), Some(5));
-    assert_eq!(text_state.text_size(), 5);
+    assert_eq!(text_state.cursor_char_index(), Some(5));
+    assert_eq!(text_state.text_char_len(), 5);
 
     // Try to delete a character at the end of the text
     // This should panic due to the bug
@@ -196,9 +195,9 @@ pub fn test_delete_at_end_of_text() {
 
     // The following assertions should not be reached if the code panics
     assert!(matches!(result, ActionResult::TextChanged));
-    assert_eq!(text_state.text_size(), 4);
+    assert_eq!(text_state.text_char_len(), 4);
     assert_eq!(text_state.text(), "Hell");
-    assert_eq!(text_state.cursor.char_index(text_state.text()), Some(4));
+    assert_eq!(text_state.cursor_char_index(), Some(4));
 }
 
 #[test]
@@ -210,14 +209,14 @@ pub fn test_insert_newline_at_end_of_text() {
     let initial_text = "Hello".to_string();
 
     let mut text_state = TextState::new_with_text(initial_text, text_id, &mut ctx.font_system);
-    text_state.params.set_style(&mono_style_test());
-    text_state.params.set_size(&Point::from((200.0, 25.0)));
+    text_state.set_style(&mono_style_test());
+    text_state.set_outer_size(&Point::from((200.0, 25.0)));
     text_state.is_editable = true;
     text_state.is_editing = true;
     text_state.is_selectable = true;
     text_state.are_actions_enabled = true;
 
-    text_state.recalculate(&mut ctx, UpdateReason::Unknown);
+    text_state.recalculate(&mut ctx);
 
     // Move cursor to the end of the text
     for _ in 0..5 {
@@ -225,8 +224,8 @@ pub fn test_insert_newline_at_end_of_text() {
     }
 
     // Verify cursor is at the end of the text
-    assert_eq!(text_state.cursor.char_index(text_state.text()), Some(5));
-    assert_eq!(text_state.text_size(), 5);
+    assert_eq!(text_state.cursor_char_index(), Some(5));
+    assert_eq!(text_state.text_char_len(), 5);
 
     // Try to delete a character at the end of the text
     // This should panic due to the bug
@@ -234,7 +233,7 @@ pub fn test_insert_newline_at_end_of_text() {
 
     // The following assertions should not be reached if the code panics
     assert!(matches!(result, ActionResult::TextChanged));
-    assert_eq!(text_state.text_size(), 6);
+    assert_eq!(text_state.text_char_len(), 6);
     assert_eq!(text_state.text(), "Hello\n");
-    assert_eq!(text_state.cursor.char_index(text_state.text()), Some(6));
+    assert_eq!(text_state.cursor_char_index(), Some(6));
 }

--- a/src/tests/copy_selected_text.rs
+++ b/src/tests/copy_selected_text.rs
@@ -1,4 +1,3 @@
-use crate::state::UpdateReason;
 use crate::tests::mono_style_test;
 use crate::{Action, ActionResult, Id, Point, TextContext, TextState};
 
@@ -10,17 +9,17 @@ pub fn test_copy_empty_selection() {
 
     let mut text_state = TextState::new_with_text(initial_text, text_id, &mut ctx.font_system);
 
-    text_state.params.set_style(&mono_style_test());
-    text_state.params.set_size(&Point::from((200.0, 25.0)));
+    text_state.set_style(&mono_style_test());
+    text_state.set_outer_size(&Point::from((200.0, 25.0)));
     text_state.is_editable = true;
     text_state.is_editing = true;
     text_state.is_selectable = true;
     text_state.are_actions_enabled = true;
 
-    text_state.recalculate(&mut ctx, UpdateReason::Unknown);
+    text_state.recalculate(&mut ctx);
 
     // No selection, cursor at the beginning
-    assert_eq!(text_state.cursor.char_index(text_state.text()), Some(0));
+    assert_eq!(text_state.cursor_char_index(), Some(0));
     assert!(!text_state.is_text_selected());
 
     // Try to copy with no selection
@@ -35,18 +34,18 @@ pub fn test_copy_partial_selection() {
     let initial_text = "Hello World".to_string();
 
     let mut text_state = TextState::new_with_text(initial_text, text_id, &mut ctx.font_system);
-    text_state.params.set_style(&mono_style_test());
-    text_state.params.set_size(&Point::from((200.0, 25.0)));
+    text_state.set_style(&mono_style_test());
+    text_state.set_outer_size(&Point::from((200.0, 25.0)));
     text_state.is_editable = true;
     text_state.is_editing = true;
     text_state.is_selectable = true;
     text_state.are_actions_enabled = true;
 
-    text_state.recalculate(&mut ctx, UpdateReason::Unknown);
+    text_state.recalculate(&mut ctx);
 
     // Set up a selection by clicking and dragging
     text_state.handle_press(&mut ctx, Point { x: 0.0, y: 10.0 });
-    assert_eq!(text_state.cursor.char_index(text_state.text()), Some(0));
+    assert_eq!(text_state.cursor_char_index(), Some(0));
 
     // Simulate dragging to select "Hello"
     text_state.handle_drag(&mut ctx, true, Point { x: 40.0, y: 10.0 });
@@ -64,14 +63,14 @@ pub fn test_copy_full_selection() {
     let initial_text = "Hello World".to_string();
 
     let mut text_state = TextState::new_with_text(initial_text, text_id, &mut ctx.font_system);
-    text_state.params.set_style(&mono_style_test());
-    text_state.params.set_size(&Point::from((200.0, 25.0)));
+    text_state.set_style(&mono_style_test());
+    text_state.set_outer_size(&Point::from((200.0, 25.0)));
     text_state.is_editable = true;
     text_state.is_editing = true;
     text_state.is_selectable = true;
     text_state.are_actions_enabled = true;
 
-    text_state.recalculate(&mut ctx, UpdateReason::Unknown);
+    text_state.recalculate(&mut ctx);
 
     // Select all text
     let result = text_state.apply_action(&mut ctx, &Action::SelectAll);
@@ -93,18 +92,18 @@ pub fn test_copy_cyrillic_text() {
     let initial_text = "Привет Мир".to_string();
 
     let mut text_state = TextState::new_with_text(initial_text, text_id, &mut ctx.font_system);
-    text_state.params.set_style(&mono_style_test());
-    text_state.params.set_size(&Point::from((200.0, 25.0)));
+    text_state.set_style(&mono_style_test());
+    text_state.set_outer_size(&Point::from((200.0, 25.0)));
     text_state.is_editable = true;
     text_state.is_editing = true;
     text_state.is_selectable = true;
     text_state.are_actions_enabled = true;
 
-    text_state.recalculate(&mut ctx, UpdateReason::Unknown);
+    text_state.recalculate(&mut ctx);
 
     // Set up a selection by clicking and dragging
     text_state.handle_press(&mut ctx, Point { x: 0.0, y: 10.0 });
-    assert_eq!(text_state.cursor.char_index(text_state.text()), Some(0));
+    assert_eq!(text_state.cursor_char_index(), Some(0));
 
     // Simulate dragging to select "Привет"
     text_state.handle_drag(&mut ctx, true, Point { x: 50.0, y: 10.0 });
@@ -122,15 +121,15 @@ pub fn test_copy_after_editing() {
     let initial_text = "Hello World".to_string();
 
     let mut text_state = TextState::new_with_text(initial_text, text_id, &mut ctx.font_system);
-    text_state.params.set_style(&mono_style_test());
-    text_state.params.set_size(&Point::from((200.0, 25.0)));
+    text_state.set_style(&mono_style_test());
+    text_state.set_outer_size(&Point::from((200.0, 25.0)));
 
     text_state.is_editable = true;
     text_state.is_editing = true;
     text_state.is_selectable = true;
     text_state.are_actions_enabled = true;
 
-    text_state.recalculate(&mut ctx, UpdateReason::Unknown);
+    text_state.recalculate(&mut ctx);
 
     // Insert text at the beginning
     text_state.apply_action(&mut ctx, &Action::InsertChar("Test ".into()));
@@ -138,7 +137,7 @@ pub fn test_copy_after_editing() {
 
     // Set up a selection by clicking and dragging
     text_state.handle_press(&mut ctx, Point { x: 0.0, y: 10.0 });
-    assert_eq!(text_state.cursor.char_index(text_state.text()), Some(0));
+    assert_eq!(text_state.cursor_char_index(), Some(0));
 
     // Simulate dragging to select "Test "
     text_state.handle_drag(&mut ctx, true, Point { x: 40.0, y: 10.0 });
@@ -156,14 +155,14 @@ pub fn test_copy_selection_from_middle() {
     let initial_text = "The quick brown fox jumps over the lazy dog".to_string();
 
     let mut text_state = TextState::new_with_text(initial_text, text_id, &mut ctx.font_system);
-    text_state.params.set_style(&mono_style_test());
-    text_state.params.set_size(&Point::from((400.0, 25.0)));
+    text_state.set_style(&mono_style_test());
+    text_state.set_outer_size(&Point::from((400.0, 25.0)));
     text_state.is_editable = true;
     text_state.is_editing = true;
     text_state.is_selectable = true;
     text_state.are_actions_enabled = true;
 
-    text_state.recalculate(&mut ctx, UpdateReason::Unknown);
+    text_state.recalculate(&mut ctx);
 
     // Position cursor before the middle of the line (at 'b' in "brown")
     // First, get the mono width to calculate the position
@@ -180,7 +179,7 @@ pub fn test_copy_selection_from_middle() {
     );
 
     // Verify cursor position after clicking
-    let cursor_pos_after_click = text_state.cursor.char_index(text_state.text());
+    let cursor_pos_after_click = text_state.cursor_char_index();
     assert_eq!(cursor_pos_after_click, Some(10)); // Should be at 'b' in "brown"
 
     // Drag for a couple of symbols (select "bro")

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,6 +1,6 @@
-use std::{ops::Deref, sync::Arc};
 #[cfg(feature = "serialization")]
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use std::{ops::Deref, sync::Arc};
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub enum ArcCowStr {


### PR DESCRIPTION
This PR cleans up `TextState` interface a bit